### PR TITLE
updated the tests

### DIFF
--- a/testing/test_terminal.py
+++ b/testing/test_terminal.py
@@ -3070,25 +3070,34 @@ def test_xpass_output(pytester: Pytester) -> None:
 
 
 class TestNodeIDHandling:
-    def test_nodeid_handling_windows_paths(self, pytester: Pytester) -> None:
+    def test_nodeid_handling_windows_paths(self, pytester: Pytester, tmp_path) -> None:
         """Test the correct handling of Windows-style paths with backslashes."""
-        pytester.makepyfile(
-            """
-            import pytest
+        pytester.makeini("[pytest]")  # Change `config.rootpath`
 
-            @pytest.mark.parametrize("a", ["x/y", "C:/path", "\\\\", "C:\\\\path", "a::b/"])
-            def test_x(a):
-                assert False
-            """
+        test_path = pytester.path / "tests" / "test_foo.py"
+        test_path.parent.mkdir()
+        os.chdir(test_path.parent)  # Change `config.invocation_params.dir`
+
+        test_path.write_text(
+            textwrap.dedent(
+                """
+                import pytest
+
+                @pytest.mark.parametrize("a", ["x/y", "C:/path", "\\\\", "C:\\\\path", "a::b/"])
+                def test_x(a):
+                    assert False
+                """
+            )
         )
+
         result = pytester.runpytest("-v")
 
         result.stdout.re_match_lines(
             [
-                r".*test_nodeid_handling_windows_paths.py::test_x\[x/y\] .*FAILED.*",
-                r".*test_nodeid_handling_windows_paths.py::test_x\[C:/path\] .*FAILED.*",
-                r".*test_nodeid_handling_windows_paths.py::test_x\[\\\\\] .*FAILED.*",
-                r".*test_nodeid_handling_windows_paths.py::test_x\[C:\\\\path\] .*FAILED.*",
-                r".*test_nodeid_handling_windows_paths.py::test_x\[a::b/\] .*FAILED.*",
+                r".*test_foo.py::test_x\[x/y\] .*FAILED.*",
+                r".*test_foo.py::test_x\[C:/path\] .*FAILED.*",
+                r".*test_foo.py::test_x\[\\\\\] .*FAILED.*",
+                r".*test_foo.py::test_x\[C:\\\\path\] .*FAILED.*",
+                r".*test_foo.py::test_x\[a::b/\] .*FAILED.*",
             ]
         )


### PR DESCRIPTION
Hi, I have updated the tests to more intuitively represent the premise of reproducing the use case: 
the parent directory of `pytest.ini` is inconsistent with the directory where the use case is executed.

Make the old version of Pytest fail when executing this test.

Resolve the review of https://github.com/pytest-dev/pytest/pull/12760